### PR TITLE
fix <time> element

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
                 {% if site.owner.name %}
                 by {{site.owner.name}},
                 {% endif %}
-    			<time class="timeago" datetime="{{ page.date |  date: "%A %-d %B %Y" }}">{{ page.date }}</time>,
+    			<time class="timeago" datetime="{{ page.date }}">{{ page.date |  date: "%A %-d %B %Y" }}</time>,
     			<a href="{{ page.url }}#disqus_thread">0 <i class="fa fa-comments-o fa-lg"></i></a>
     			comments.
     		</div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
         <div class="post-li">
             <div class="col-sm-8">
                 <ul class="postlist-block">
-                    <li><time class="timeago postlist-meta" datetime="{{ post.date |  date: "%A %-d %B %Y" }}">{{ post.date }}</time>
+                    <li><time class="timeago postlist-meta" datetime="{{ post.date }}">{{ post.date |  date: "%A %-d %B %Y" }}</time>
                     <a class="postlist-meta pull-right comments-meta" href="{{ post.url }}#disqus_thread">0 <i class="fa fa-comments-o fa-lg"></i></a></li>
                     <li><a class="postlist-title" href="{{ post.url }}">{{ post.title }}</a></li>
                 </ul>

--- a/tags.html
+++ b/tags.html
@@ -34,7 +34,7 @@ title: Tags
                 {% for post in site.tags[this_word] %}{% if post.title != null %}
                 <li class="tag-pages" id="tag-pages{{item}}">
                     <span class="entry-date leaders-left">
-                        <time class="timeago" datetime="{{ post.date | date: "%A %-d %B %Y" }}" itemprop="datePublished">{{ post.date }}</time>
+                        <time class="timeago" datetime="{{ post.date }}" itemprop="datePublished">{{ post.date | date: "%A %-d %B %Y" }}</time>
                     </span>
                     <a class="leaders-right" href="{{ post.url }}">{{ post.title }}</a>
                 </li>


### PR DESCRIPTION
The property 'datetime' should recognizable by timeago plugin.

While the text node of <time> elements should be human readable as a fallback mechansim for the situation when the timeago plugin does not work.
